### PR TITLE
Fix: Removed duplicate public security group

### DIFF
--- a/LabYaml
+++ b/LabYaml
@@ -39,7 +39,6 @@ Parameters:
   
   KeyName:
     Type: AWS::EC2::KeyPair::KeyName
-    Default: labkeypair
     Description: SSH Keypair to login to the instance
 
 Resources:
@@ -115,10 +114,10 @@ Resources:
         Ref: labPublicRouteTable
 
   #Creating an instance security group
-  InstanceSecurityGroup:
+  labPublicInstanceSG:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Allow http to client host
+      GroupDescription: Allow http and ssh to public subnet
       VpcId: 
         Ref: labVPC
       SecurityGroupIngress:
@@ -163,19 +162,6 @@ Resources:
       RouteTableId:
         Ref: labPrivateRouteTable
   
-  #Creating a Security Group for the public EC2 instance
-  labPublicInstanceSG:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Allow SSH access to the public instance
-      VpcId: 
-        Ref: labVPC
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp: 0.0.0.0/0
-
   #Creating a Security Group for the private EC2 instance
   labPrivateInstanceSG:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
Removed duplicate  public security group and removed default KeyName from parameters.